### PR TITLE
Specify the Python version

### DIFF
--- a/IV110.yml
+++ b/IV110.yml
@@ -3,3 +3,4 @@ channels:
   - bioconda
 dependencies:
   - snakemake-minimal
+  - python=3.10


### PR DESCRIPTION
* I had 3.11 by default and then one of the conda evironments could not be built