### PR TITLE
Update preprocessing and assembly steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,7 @@ and, on the other hand, not include the used ones.
     - [MinIONQC](https://github.com/roblanf/minion_qc)
 3. Filtering, trimming, adapter removal
     - [Porechop](https://github.com/rrwick/Porechop)
-    - [NanoFilt](https://github.com/wdecoster/nanofilt)
 4. Genome assembly
-    - [Unicycler](https://github.com/rrwick/Unicycler)
+    - [Flye](https://github.com/fenderglass/Flye)
     - [medaka](https://github.com/nanoporetech/medaka) [error correction]
 

--- a/Snakefile
+++ b/Snakefile
@@ -3,7 +3,7 @@ configfile: "config.yml"
 BASECALLED_DIR = config['basecalled_local']
 OUTPUT_DIR = config['outputs_local']
 # BARCODES = ["barcode03", "barcode04", "barcode07", "barcode08"]
-BARCODES = ["barcode08"]
+BARCODES = ["barcode03"]
 
 
 rule all:
@@ -36,6 +36,7 @@ rule basecalling:
         f"{OUTPUT_DIR}/guppy/{{barcode}}/sequencing_summary.txt"
     shell:
         "guppy_basecaller --input_path {input} --save_path {params.prefix} --flowcell FLO-MIN106 --kit SQK-RBK004"
+
 
 rule merge_fastq:
     input:
@@ -79,30 +80,6 @@ rule porechop:
         "envs/porechop.yaml"
     shell:
         "porechop -i {input} -o {output} --discard_middle"
-
-
-# rule nanofilt:
-#     input:
-#         f"{OUTPUT_DIR}/porechop/{{barcode}}/reads-porechop.fastq.gz"
-#     output:
-#         f"{OUTPUT_DIR}/nanofilt/{{barcode}}/reads-nanofilt.fastq.gz"
-#     conda:
-#         "envs/nanofilt.yaml"
-#     shell:
-#         "gunzip -c {input} | NanoFilt -q 8 | gzip > {output}"
-
-
-# rule unicycler:
-#     input:
-#         f"{OUTPUT_DIR}/nanofilt/{{barcode}}/reads-nanofilt.fastq.gz"
-#     output:
-#         f"{OUTPUT_DIR}/unicycler/{{barcode}}/assembly.fasta"
-#     params:
-#         output_dir=f"{OUTPUT_DIR}/unicycler/{{barcode}}"
-#     conda:
-#         "envs/unicycler.yaml"
-#     shell:
-#         "unicycler -l {input} -o {params.output_dir}"
 
 
 rule flye:

--- a/Snakefile
+++ b/Snakefile
@@ -81,34 +81,47 @@ rule porechop:
         "porechop -i {input} -o {output} --discard_middle"
 
 
-rule nanofilt:
+# rule nanofilt:
+#     input:
+#         f"{OUTPUT_DIR}/porechop/{{barcode}}/reads-porechop.fastq.gz"
+#     output:
+#         f"{OUTPUT_DIR}/nanofilt/{{barcode}}/reads-nanofilt.fastq.gz"
+#     conda:
+#         "envs/nanofilt.yaml"
+#     shell:
+#         "gunzip -c {input} | NanoFilt -q 8 | gzip > {output}"
+
+
+# rule unicycler:
+#     input:
+#         f"{OUTPUT_DIR}/nanofilt/{{barcode}}/reads-nanofilt.fastq.gz"
+#     output:
+#         f"{OUTPUT_DIR}/unicycler/{{barcode}}/assembly.fasta"
+#     params:
+#         output_dir=f"{OUTPUT_DIR}/unicycler/{{barcode}}"
+#     conda:
+#         "envs/unicycler.yaml"
+#     shell:
+#         "unicycler -l {input} -o {params.output_dir}"
+
+
+rule flye:
     input:
         f"{OUTPUT_DIR}/porechop/{{barcode}}/reads-porechop.fastq.gz"
     output:
-        f"{OUTPUT_DIR}/nanofilt/{{barcode}}/reads-nanofilt.fastq.gz"
-    conda:
-        "envs/nanofilt.yaml"
-    shell:
-        "gunzip -c {input} | NanoFilt -q 8 | gzip > {output}"
-
-
-rule unicycler:
-    input:
-        f"{OUTPUT_DIR}/nanofilt/{{barcode}}/reads-nanofilt.fastq.gz"
-    output:
-        f"{OUTPUT_DIR}/unicycler/{{barcode}}/assembly.fasta"
+        f"{OUTPUT_DIR}/flye/{{barcode}}/assembly.fasta"
     params:
-        output_dir=f"{OUTPUT_DIR}/unicycler/{{barcode}}"
+        output_dir=f"{OUTPUT_DIR}/flye/{{barcode}}"
     conda:
-        "envs/unicycler.yaml"
+        "envs/flye.yaml"
     shell:
-        "unicycler -l {input} -o {params.output_dir}"
+        "flye --nano-raw {input} -o {params.output_dir} --threads 4"
 
 
 rule medaka:
     input:
-        assembly=f"{OUTPUT_DIR}/unicycler/{{barcode}}/assembly.fasta",
-        raw_reads=f"{OUTPUT_DIR}/merged_fastq/{{barcode}}/reads.fastq.gz"
+        assembly=f"{OUTPUT_DIR}/flye/{{barcode}}/assembly.fasta",
+        raw_reads=f"{OUTPUT_DIR}/porechop/{{barcode}}/reads-porechop.fastq.gz"
     output:
         f"{OUTPUT_DIR}/medaka/{{barcode}}/consensus.fasta"
     params:

--- a/Snakefile
+++ b/Snakefile
@@ -92,7 +92,7 @@ rule flye:
     conda:
         "envs/flye.yaml"
     shell:
-        "flye --nano-raw {input} -o {params.output_dir} --threads 4"
+        "flye --nano-raw {input} -o {params.output_dir} --meta --threads 4"
 
 
 rule medaka:

--- a/envs/flye.yaml
+++ b/envs/flye.yaml
@@ -1,0 +1,5 @@
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - flye=2.9.1

--- a/envs/nanofilt.yaml
+++ b/envs/nanofilt.yaml
@@ -1,5 +1,0 @@
-channels:
-  - conda-forge
-  - bioconda
-dependencies:
-  - nanofilt=2.8.0


### PR DESCRIPTION
- replaced Unicycler with [Flye assembler](https://github.com/fenderglass/Flye)
    - with `--meta` option - [metagenome assembly mode](https://github.com/fenderglass/Flye/blob/flye/docs/USAGE.md#:~:text=Metagenome%20mode,outperforms%20metageomic%20mode.)
- removed filtering step with Nanofilt
   - according to this [article](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC8486125/#:~:text=ONT%20recommends%20to%20keep%20only%20reads%20with%20a%20quality%20score%20above%207.), ONT recommends to keep reads with a quality score above 7
   - we might not need it since guppy filters out reads with quality score below 7